### PR TITLE
Percent-encode subject query parameter

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -32,9 +32,9 @@
 	</section>
 	<div class="email-reply">
 {{ if .Title }}
-		<a class="reply" href="mailto:{{ .Site.Params.mailto }}?subject=Reply to {{ .Title }}">Reply by email</a>
+		<a class="reply" href="mailto:{{ .Site.Params.mailto }}?subject=Reply%20to%20{{ .Title }}">Reply by email</a>
 {{ else }}
-<a class="reply" href="mailto:{{ .Site.Params.mailto }}?subject=Reply to {{ .Permalink | safeURL }}">Reply by email</a>
+<a class="reply" href="mailto:{{ .Site.Params.mailto }}?subject=Reply%20to%20{{ .Permalink | safeURL }}">Reply by email</a>
 {{ end }}
 	</div>
 	{{ if .Site.Params.include_conversation }}


### PR DESCRIPTION
I stumbled upon your awesome theme while working on [my plug-in](https://micro.blog/sod/12291426). I noticed that the current reply by email implementation [causes HTML validation errors](https://validator.w3.org/nu/?doc=https%3A%2F%2Fpimoore.ca%2F2021%2F12%2F21%2Flifes-embers.html#vnuId3) due to spaces in the URL.

> **Error:** Bad value `mailto:redacted@example.com?subject=Reply to Life%e2%80%99s%20Embers` for attribute `href` on element `a`: Illegal character in query: space is not allowed.

Even if most browsers handle spaces gracefully in most cases, I propose percent-encoding to eliminate the error.