### PR TITLE
Fixed empty archive page

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,25 +24,11 @@
 			"isPlainText": true,
 			"notAlternative": true
 		},
-		"ArchiveHTML": {
-			"mediaType": "text/html",
-			"path": "archive",
-			"baseName": "index",
-			"isPlainText": false,
-			"notAlternative": true
-		},
 		"ArchiveJSON": {
 			"mediaType": "application/json",
 			"path": "archive",
 			"baseName": "index",
 			"isPlainText": true,
-			"notAlternative": true
-		},
-		"PhotosHTML": {
-			"mediaType": "text/html",
-			"path": "photos",
-			"baseName": "index",
-			"isPlainText": false,
 			"notAlternative": true
 		},
 		"PhotosJSON": {
@@ -66,7 +52,7 @@
 		}
 	},
 	"outputs": {
-		"home": [ "HTML", "RSS", "JSON", "RSD", "ArchiveHTML", "ArchiveJSON", "PhotosJSON", "PodcastXML", "PodcastJSON" ],
+		"home": [ "HTML", "RSS", "JSON", "RSD", "ArchiveJSON", "PhotosJSON", "PodcastXML", "PodcastJSON" ],
 		"page": [ "HTML" ],
 		"section": [ "HTML" ],
 		"taxonomy": [ "HTML", "RSS", "JSON" ],


### PR DESCRIPTION
Updated the config to remove references to the old way of doing archive/photos pages. Actually almost all of this file can be removed, but I'm just removing the bare minimum for now in case you rely on anything else.