### PR TITLE
Change category links to be relative

### DIFF
--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -16,7 +16,7 @@
 						{{ if gt $i 0 }}
 							<span>•</span>
 						{{ end }}
-						<a class="article-category-link" href="{{ $Site.BaseURL }}/categories/{{ $e | urlize }}">{{ $e }}</a>
+						<a class="article-category-link" href="/categories/{{ $e | urlize }}">{{ $e }}</a>
 					{{ end }}
 				</span>
 			</span>


### PR DESCRIPTION
When `{{ $Site.BaseURL }}/categories/{{ $e | urlize }}` is used as the `href` attribute for article categories, they end up generating URLs like `https://username.micro.blog//categories/example` with an extra forward slash. I think the `$Site.BaseURL` variable has a trailing slash, so this could probably also be changed to `{{ $Site.BaseURL }}categories/{{ $e | urlize }}`… However, unless I'm missing something, I think these URLs could just be changed to be relative 😄