### PR TITLE
Update style.css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -256,9 +256,6 @@ video, audio {
 	max-width: 55%;
 } 
 
-.content.page img {
-	max-width: 55%;
-}
 
 /* Newthought element styling
 	- shortcode to start highlight the first few words of a new section or thought */


### PR DESCRIPTION
(Installed using MicroBlog Tufte Plugin)  - did not allow full, regular, margin rendering to be correct with figures. Everything was reduced to 55%. Removing following code seems to have solved the issue.


.content.page img {
max-width: 55%;
}