### PR TITLE
Remove common Micro.blog elements from head and use new partial instead

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,36 +8,7 @@
 	{{ partial "meta.html" . }}
 	{{ partial "og.html" . }}
 
-	{{ if .RSSLink -}}
-		<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-		<link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
-		<link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
-		<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-	{{ end -}}
-
-	<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
-	{{ with .Site.Params.twitter_username }}
-		<link rel="me" href="https://twitter.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.github_username }}
-		<link rel="me" href="https://github.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.instagram_username }}
-		<link rel="me" href="https://instagram.com/{{ . }}" />
-	{{ end }}
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-	<link rel="micropub" href="https://micro.blog/micropub" />
-	<link rel="microsub" href="https://micro.blog/microsub" />
-	<link rel="webmention" href="https://micro.blog/webmention" />
-	<link rel="subscribe" href="https://micro.blog/users/follow" />
-	<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
 	<link rel="stylesheet" href="{{ "css/style.css" | absURL }}?{{ .Site.Params.theme_seconds }}">
-	<link rel="stylesheet" type="text/css" href="{{ "custom.css" | relURL }}?{{ .Site.Params.theme_seconds }}" />
-	{{ range .Site.Params.plugins_css }}
-		<link rel="stylesheet" href="{{ . }}" />
-	{{ end }}
-	{{ range $filename := .Site.Params.plugins_html }}
-		{{ partial $filename $ }}
-	{{ end }}
+
+	{{ partial "microblog_head.html" . }}
 </head>


### PR DESCRIPTION
Hey! 👋 This pull request introduces the [new partial](https://github.com/microdotblog/theme-blank/blob/master/layouts/partials/microblog_head.html) that is provided by the Micro.blog environment. With that, we know that all the necessary Micro.blog head elements are present, with the added bonus of making this theme compatible with Hugo 0.117.

I'm not bumping the version number; that's up to you, @pimoore, should you decide to merge this one.