### PR TITLE
Accessibility improvements

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,7 +67,7 @@
 		"fractions": false
 	},
 	"enableRobotsTXT": true,
-	"languageCode": "[LANGUAGE]",
+	"languageCode": "en",
 	"paginate": 10,
 	"params": {
 		"description": "enter your description here",

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,11 +6,13 @@
 			<div class="archive-category-wrap">
 				<span class="archive-category">Posts in: {{ .Title }}</span>
 			</div>
-			<div class="archives">
-				{{ range .Paginator.Pages }}
-					{{ partial "li.html" . }}
-				{{ end }}
-			</div>
+			<main>
+				<div class="archives">
+					{{ range .Paginator.Pages }}
+						{{ partial "li.html" . }}
+					{{ end }}
+				</div>
+			</main>
 		</section>
 		{{ partial "pagination.html" . }}
 	</section>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,10 +2,12 @@
 <body>
 	<div class="content list h-feed">
 		{{ partial "header.html" . }}
-		{{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
-		{{ range $paginator.Pages }}
-			{{ partial "li.html" . }}
-		{{ end }}
+		<main>
+			{{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
+			{{ range $paginator.Pages }}
+				{{ partial "li.html" . }}
+			{{ end }}
+		</main>
 		{{ partial "pagination.html" . }}
 		{{ partial "footer.html" . }}
 	</div>

--- a/layouts/list.archivehtml.html
+++ b/layouts/list.archivehtml.html
@@ -3,26 +3,28 @@
 <body>
   <h1 class="page-title">{{ .Title }}</h1>
 	<div id="container" class="h-feed">
-		<section id="main" class="outer">
-			<div class="archive_categories">
-				{{ range $name, $taxonomy := $.Site.Taxonomies.categories }}
-					<p><a href="{{ "/categories/" | relURL }}{{ $name | urlize }}"> {{ $name }}</a></p>
-				{{ end }}
-			</div>
-			<hr>
-			<br><br>
-			{{ $list := (where .Site.Pages "Type" "post") }}
-			{{ range $list }}
-				<p class="h-entry" style="padding-bottom: 5px;">
-					<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>
-					{{ if .Title }}
-						<span class="p-name"><b>{{ .Title }}</b></span> 
-					{{ else }}
-						<span class="truncated">{{ .Summary | truncate 100 }}</span>
+		<main>
+			<section id="main" class="outer">
+				<div class="archive_categories">
+					{{ range $name, $taxonomy := $.Site.Taxonomies.categories }}
+						<p><a href="{{ "/categories/" | relURL }}{{ $name | urlize }}"> {{ $name }}</a></p>
 					{{ end }}
-				</p>
-			{{ end }}
-		</section>
+				</div>
+				<hr>
+				<br><br>
+				{{ $list := (where .Site.Pages "Type" "post") }}
+				{{ range $list }}
+					<p class="h-entry" style="padding-bottom: 5px;">
+						<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "2006-01-02" }}</span></a>
+						{{ if .Title }}
+							<span class="p-name"><b>{{ .Title }}</b></span> 
+						{{ else }}
+							<span class="truncated">{{ .Summary | truncate 100 }}</span>
+						{{ end }}
+					</p>
+				{{ end }}
+			</section>
+		</main>
 		{{ partial "footer.html" . }}
 	</div>
 	{{ partial "custom_footer.html" . }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,8 +1,10 @@
 {{ define "main" }}
 <div class="content page">
-  <h1 class="page-title">{{ .Title }}</h1>
-	<section>
-		{{ .Content }}
-	</section>
-</div>
+	<main>
+		<h1 class="page-title">{{ .Title }}</h1>
+		<section>
+			{{ .Content }}
+		</section>
+	</main>
+	</div>
 {{ end }}

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,46 +1,48 @@
-<article class="h-entry">
-	<div class="article-meta">
-		<span class="pubdate">Published on <time class="dt-published" datetime='{{ .Date.Format "2006-01-02T15:04:05.000-07:00" }}' itemprop="datePublished">{{ .Date.Format "Jan 2, 2006" }}</time>
-		</span>
-		<span class="permalink"><a href="{{ .RelPermalink }}">  [Permalink]</a></span><br />
-		{{ if .Title }}
-			{{ $readTime := .ReadingTime }}
-			<span class="read-time">Reading time: {{ .ReadingTime }} {{ cond (eq $readTime 1) "minute" "minutes"}}</span><br />
-		{{ end }}
-		{{ $Site := .Site }}
-		{{ if .Params.categories }}
-			<span class="catlist">Posted in: </span>
-			<span class="post-categories">
-				<span class="article-category">
-					{{ range $i, $e := .Params.categories }}
-						{{ if gt $i 0 }}
-							<span>•</span>
-						{{ end }}
-						<a class="article-category-link" href="{{ $Site.BaseURL }}/categories/{{ $e | urlize }}">{{ $e }}</a>
-					{{ end }}
-				</span>
+<main>
+	<article class="h-entry">
+		<div class="article-meta">
+			<span class="pubdate">Published on <time class="dt-published" datetime='{{ .Date.Format "2006-01-02T15:04:05.000-07:00" }}' itemprop="datePublished">{{ .Date.Format "Jan 2, 2006" }}</time>
 			</span>
+			<span class="permalink"><a href="{{ .RelPermalink }}">  [Permalink]</a></span><br />
+			{{ if .Title }}
+				{{ $readTime := .ReadingTime }}
+				<span class="read-time">Reading time: {{ .ReadingTime }} {{ cond (eq $readTime 1) "minute" "minutes"}}</span><br />
+			{{ end }}
+			{{ $Site := .Site }}
+			{{ if .Params.categories }}
+				<span class="catlist">Posted in: </span>
+				<span class="post-categories">
+					<span class="article-category">
+						{{ range $i, $e := .Params.categories }}
+							{{ if gt $i 0 }}
+								<span>•</span>
+							{{ end }}
+							<a class="article-category-link" href="{{ $Site.BaseURL }}/categories/{{ $e | urlize }}">{{ $e }}</a>
+						{{ end }}
+					</span>
+				</span>
+			{{ end }}
+			{{ if .Title }}
+				<header class="article-header">
+					<h1 class="article-title p-name" itemprop="name">{{ .Title }}</h1>
+				</header>
+			{{ end }}
+		</div>
+		<section class="e-content">
+			{{ .Content }}
+		</section>
+		<div class="email-reply">
+			{{ if templates.Exists "partials/reply-by-email.html" }}
+				  <p>{{ partial "reply-by-email.html" . }}</p>
+			{{ end }}
+		</div>
+		<div class="conversation-reply">
+		{{ if templates.Exists "partials/conversation-link.html" }}
+			  <p>{{ partial "conversation-link.html" . }}</p>
 		{{ end }}
-		{{ if .Title }}
-			<header class="article-header">
-				<h1 class="article-title p-name" itemprop="name">{{ .Title }}</h1>
-			</header>
+		</div>
+		{{ if .Site.Params.include_conversation }}
+			<script type="text/javascript" src="https://micro.blog/conversation.js?url={{ .Permalink }}"></script>
 		{{ end }}
-	</div>
-	<section class="e-content">
-		{{ .Content }}
-	</section>
-	<div class="email-reply">
-		{{ if templates.Exists "partials/reply-by-email.html" }}
-  			<p>{{ partial "reply-by-email.html" . }}</p>
-		{{ end }}
-	</div>
-	<div class="conversation-reply">
-	{{ if templates.Exists "partials/conversation-link.html" }}
-  		<p>{{ partial "conversation-link.html" . }}</p>
-	{{ end }}
-	</div>
-	{{ if .Site.Params.include_conversation }}
-		<script type="text/javascript" src="https://micro.blog/conversation.js?url={{ .Permalink }}"></script>
-	{{ end }}
-</article>
+	</article>
+</main>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.LanguageCode }}">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,10 @@
 <header id="header">
 	<div id="header-outer" class="outer">
 		<div id="header-inner" class="inner">
-			<a id="main-nav-toggle" class="nav-icon" href="javascript:;"></a>
+			<a id="main-nav-toggle" class="nav-icon" href="javascript:;" aria-label="Toggle main nav"></a>
 			<a id="logo" class="logo-text" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
 			<p class="subtitle">{{ .Site.Params.subtitle }}</p>
-			<nav id="main-nav">
+			<nav id="main-nav" aria-label="Navigation menu">
 				{{ range .Site.Menus.main }}
 					<a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a>
 				{{ end }}
@@ -13,7 +13,7 @@
 				{{ end }}
 				<a class="main-nav-link" href="{{ "feed.xml" | absURL }}">RSS</a>
 			</nav>
-			<nav id="sub-nav">
+			<nav id="sub-nav" aria-label="Search form">
 				<div id="search-form-wrap">
 				</div>
 			</nav>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ .Site.Params.Description }}">
 <meta name="keywords" content="{{ range .Site.Params.Keywords }}{{ . }},{{ end }}">
 <meta name="author" content="{{ .Site.Params.Author }}">

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,5 +1,5 @@
 {{ $pag := $.Paginator }}
-<nav id="page-nav">
+<nav id="page-nav" aria-label="Page navigator">
 	{{ if $pag.HasPrev }}
 		<span class="prev">
 			<a href="{{ $pag.Prev.URL }}">

--- a/plugin.json
+++ b/plugin.json
@@ -12,6 +12,11 @@
 			"field": "params.description",
 			"label": "Description",
 			"placeholder": "Enter your description here"
+		},
+		{
+			"field": "languageCode",
+			"label": "Language",
+			"placeholder": "Enter the language code (ISO 639-1) for your content to improve accessibility"
 		}
 	]
 }


### PR DESCRIPTION
Hello!

This was a brief effort into improving the basic accessibility concerns from automated checkers such as PageSpeed Insights and axe DevTools. **All changes should maintain the current displayed output** as the only changes are to attributes that provide additional information to browsers.

### Changes:
- Added `<main>` tags around primary content in templates
- Added language attribute to `<html>` using the standard Hugo `languageCode` parameter as in the [standard Hugo alias template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/alias.html), currently set to `en` as a default value in `config.json` which I feel is particularly opinionated and suboptimal. My current compromise was to add it as a parameter in the Micro.blog plugin settings but I'd welcome any other suggestions here
- Added `aria-label` text where missing, mostly for `<a>` tags without any inner text
- Removing the `maximum-scale` viewport attribute

### Results:
- Near-perfect accessibility scores on PageSpeed Insights and axe DevTools except for the two features not changed, listed below

### Potential changes not made:
- The remaining accessibility issue on axe automated testing was lacking an `<h1>` tag on pages with no post containing a title, which I don't see a straightforward solution for
- The remaining issue on PageSpeed Insights was insufficient contrast between the subtitle text and the background, which can be fixed if the `p.subtitle` color is changed from `gray` to `dimgray` or similar, but this is obviously a rendering change so I decided to leave it out for now

Ideally I would do some automated testing to make sure the rendered output hasn't changed, but I'm not familiar with how to do that so I at least tested the fork on a Micro.blog test site and all appears in order: [Test site](https://vinayh-test.micro.blog/)

Happy to hear your feedback, and thanks for your work so far in porting this theme to Micro.blog! 😄